### PR TITLE
Fixed #33308 -- Added support for psycopg version 3.

### DIFF
--- a/django/contrib/gis/db/backends/postgis/base.py
+++ b/django/contrib/gis/db/backends/postgis/base.py
@@ -1,16 +1,92 @@
-from django.db.backends.base.base import NO_DB_ALIAS
-from django.db.backends.postgresql.base import (
-    DatabaseWrapper as Psycopg2DatabaseWrapper,
-)
+from functools import lru_cache
 
+from django.db.backends.base.base import NO_DB_ALIAS
+from django.db.backends.postgresql.base import DatabaseWrapper as PsycopgDatabaseWrapper
+from django.db.backends.postgresql.psycopg_any import is_psycopg3
+
+from .adapter import PostGISAdapter
 from .features import DatabaseFeatures
 from .introspection import PostGISIntrospection
 from .operations import PostGISOperations
 from .schema import PostGISSchemaEditor
 
+if is_psycopg3:
+    from psycopg.adapt import Dumper
+    from psycopg.pq import Format
+    from psycopg.types import TypeInfo
+    from psycopg.types.string import TextBinaryLoader, TextLoader
 
-class DatabaseWrapper(Psycopg2DatabaseWrapper):
+    class GeometryType:
+        pass
+
+    class GeographyType:
+        pass
+
+    class RasterType:
+        pass
+
+    class BaseTextDumper(Dumper):
+        def dump(self, obj):
+            # Return bytes as hex for text formatting
+            return obj.ewkb.hex().encode()
+
+    class BaseBinaryDumper(Dumper):
+        format = Format.BINARY
+
+        def dump(self, obj):
+            return obj.ewkb
+
+    @lru_cache
+    def postgis_adapters(geo_oid, geog_oid, raster_oid):
+        class BaseDumper(Dumper):
+            def __init_subclass__(cls, base_dumper):
+                super().__init_subclass__()
+
+                cls.GeometryDumper = type(
+                    "GeometryDumper", (base_dumper,), {"oid": geo_oid}
+                )
+                cls.GeographyDumper = type(
+                    "GeographyDumper", (base_dumper,), {"oid": geog_oid}
+                )
+                cls.RasterDumper = type(
+                    "RasterDumper", (BaseTextDumper,), {"oid": raster_oid}
+                )
+
+            def get_key(self, obj, format):
+                if obj.is_geometry:
+                    return GeographyType if obj.geography else GeometryType
+                else:
+                    return RasterType
+
+            def upgrade(self, obj, format):
+                if obj.is_geometry:
+                    if obj.geography:
+                        return self.GeographyDumper(GeographyType)
+                    else:
+                        return self.GeometryDumper(GeometryType)
+                else:
+                    return self.RasterDumper(RasterType)
+
+            def dump(self, obj):
+                raise NotImplementedError
+
+        class PostGISTextDumper(BaseDumper, base_dumper=BaseTextDumper):
+            pass
+
+        class PostGISBinaryDumper(BaseDumper, base_dumper=BaseBinaryDumper):
+            format = Format.BINARY
+
+        return PostGISTextDumper, PostGISBinaryDumper
+
+
+class DatabaseWrapper(PsycopgDatabaseWrapper):
     SchemaEditorClass = PostGISSchemaEditor
+
+    _type_infos = {
+        "geometry": {},
+        "geography": {},
+        "raster": {},
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -24,3 +100,45 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
         # Check that postgis extension is installed.
         with self.cursor() as cursor:
             cursor.execute("CREATE EXTENSION IF NOT EXISTS postgis")
+            if is_psycopg3:
+                # Ensure adapters are registers if PostGIS is used within this
+                # connection.
+                self.register_geometry_adapters(self.connection, True)
+
+    def get_new_connection(self, conn_params):
+        connection = super().get_new_connection(conn_params)
+        if is_psycopg3:
+            self.register_geometry_adapters(connection)
+        return connection
+
+    if is_psycopg3:
+
+        def _register_type(self, pg_connection, typename):
+            registry = self._type_infos[typename]
+            try:
+                info = registry[self.alias]
+            except KeyError:
+                info = TypeInfo.fetch(pg_connection, typename)
+                registry[self.alias] = info
+
+            if info:  # Can be None if the type does not exist (yet).
+                info.register(pg_connection)
+                pg_connection.adapters.register_loader(info.oid, TextLoader)
+                pg_connection.adapters.register_loader(info.oid, TextBinaryLoader)
+
+            return info.oid if info else None
+
+        def register_geometry_adapters(self, pg_connection, clear_caches=False):
+            if clear_caches:
+                for typename in self._type_infos:
+                    self._type_infos[typename].pop(self.alias, None)
+
+            geo_oid = self._register_type(pg_connection, "geometry")
+            geog_oid = self._register_type(pg_connection, "geography")
+            raster_oid = self._register_type(pg_connection, "raster")
+
+            PostGISTextDumper, PostGISBinaryDumper = postgis_adapters(
+                geo_oid, geog_oid, raster_oid
+            )
+            pg_connection.adapters.register_dumper(PostGISAdapter, PostGISTextDumper)
+            pg_connection.adapters.register_dumper(PostGISAdapter, PostGISBinaryDumper)

--- a/django/contrib/gis/db/backends/postgis/features.py
+++ b/django/contrib/gis/db/backends/postgis/features.py
@@ -1,10 +1,10 @@
 from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures
 from django.db.backends.postgresql.features import (
-    DatabaseFeatures as Psycopg2DatabaseFeatures,
+    DatabaseFeatures as PsycopgDatabaseFeatures,
 )
 
 
-class DatabaseFeatures(BaseSpatialFeatures, Psycopg2DatabaseFeatures):
+class DatabaseFeatures(BaseSpatialFeatures, PsycopgDatabaseFeatures):
     supports_geography = True
     supports_3d_storage = True
     supports_3d_functions = True

--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -13,6 +13,7 @@ from django.contrib.gis.measure import Distance
 from django.core.exceptions import ImproperlyConfigured
 from django.db import NotSupportedError, ProgrammingError
 from django.db.backends.postgresql.operations import DatabaseOperations
+from django.db.backends.postgresql.psycopg_any import is_psycopg3
 from django.db.models import Func, Value
 from django.utils.functional import cached_property
 from django.utils.version import get_version_tuple
@@ -141,7 +142,8 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
 
     unsupported_functions = set()
 
-    select = '%s::bytea'
+    select = "%s" if is_psycopg3 else "%s::bytea"
+
     select_extent = None
 
     @cached_property
@@ -383,7 +385,10 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         geom_class = expression.output_field.geom_class
 
         def converter(value, expression, connection):
+            if isinstance(value, str):  # Coming from hex strings.
+                value = value.encode("ascii")
             return None if value is None else GEOSGeometryBase(read(value), geom_class)
+
         return converter
 
     def get_area_att_for_field(self, field):

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -1,10 +1,15 @@
 import datetime
 import json
 
-from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange, Range
-
 from django.contrib.postgres import forms, lookups
 from django.db import models
+from django.db.backends.postgresql.psycopg_any import (
+    DateRange,
+    DateTimeTZRange,
+    NumericRange,
+    Range,
+)
+from django.db.models.functions import Cast
 from django.db.models.lookups import PostgresOperatorLookup
 
 from .utils import AttributeSetter
@@ -157,7 +162,14 @@ class DateRangeField(RangeField):
         return 'daterange'
 
 
-RangeField.register_lookup(lookups.DataContains)
+class RangeContains(lookups.DataContains):
+    def get_prep_lookup(self):
+        if not isinstance(self.rhs, (list, tuple, Range)):
+            return Cast(self.rhs, self.lhs.field.base_field)
+        return super().get_prep_lookup()
+
+
+RangeField.register_lookup(RangeContains)
 RangeField.register_lookup(lookups.ContainedBy)
 RangeField.register_lookup(lookups.Overlap)
 

--- a/django/contrib/postgres/operations.py
+++ b/django/contrib/postgres/operations.py
@@ -32,6 +32,10 @@ class CreateExtension(Operation):
         # installed, otherwise a subsequent data migration would use the same
         # connection.
         register_type_handlers(schema_editor.connection)
+        if hasattr(schema_editor.connection, "register_geometry_adapters"):
+            schema_editor.connection.register_geometry_adapters(
+                schema_editor.connection.connection, True
+            )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         if not router.allow_migrate(schema_editor.connection.alias, app_label):

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -1,5 +1,3 @@
-import psycopg2
-
 from django.db.models import (
     CharField, Expression, Field, FloatField, Func, Lookup, TextField, Value,
 )
@@ -34,6 +32,11 @@ class SearchQueryField(Field):
 
     def db_type(self, connection):
         return 'tsquery'
+
+
+class _Float4Field(Field):
+    def db_type(self, connection):
+        return "float4"
 
 
 class SearchConfig(Expression):
@@ -118,7 +121,11 @@ class SearchVector(SearchVectorCombinable, Func):
         if clone.weight:
             weight_sql, extra_params = compiler.compile(clone.weight)
             sql = 'setweight({}, {})'.format(sql, weight_sql)
-        return sql, config_params + params + extra_params
+
+        # These parameters must be bound on the client side because we may
+        # want to create an index on this expression.
+        sql = connection.ops.compose_sql(sql, config_params + params + extra_params)
+        return sql, []
 
 
 class CombinedSearchVector(SearchVectorCombinable, CombinedExpression):
@@ -212,6 +219,8 @@ class SearchRank(Func):
         self, vector, query, weights=None, normalization=None,
         cover_density=False,
     ):
+        from .fields.array import ArrayField
+
         if not hasattr(vector, 'resolve_expression'):
             vector = SearchVector(vector)
         if not hasattr(query, 'resolve_expression'):
@@ -220,6 +229,7 @@ class SearchRank(Func):
         if weights is not None:
             if not hasattr(weights, 'resolve_expression'):
                 weights = Value(weights)
+            weights = Cast(weights, ArrayField(_Float4Field()))
             expressions = (weights,) + expressions
         if normalization is not None:
             if not hasattr(normalization, 'resolve_expression'):
@@ -266,14 +276,13 @@ class SearchHeadline(Func):
         options_sql = ''
         options_params = []
         if self.options:
-            # getquoted() returns a quoted bytestring of the adapted value.
-            options_params.append(', '.join(
-                '%s=%s' % (
-                    option,
-                    psycopg2.extensions.adapt(value).getquoted().decode(),
-                ) for option, value in self.options.items()
-            ))
-            options_sql = ', %s'
+            options_params.append(
+                ", ".join(
+                    connection.ops.compose_sql(f"{option}=%s", [value])
+                    for option, value in self.options.items()
+                )
+            )
+            options_sql = ", %s"
         sql, params = super().as_sql(
             compiler, connection, function=function, template=template,
             options=options_sql,

--- a/django/contrib/postgres/signals.py
+++ b/django/contrib/postgres/signals.py
@@ -1,22 +1,14 @@
 import functools
 
-import psycopg2
-from psycopg2 import ProgrammingError
-from psycopg2.extras import register_hstore
-
 from django.db import connections
 from django.db.backends.base.base import NO_DB_ALIAS
+from django.db.backends.postgresql.psycopg_any import is_psycopg3
 
 
-@functools.lru_cache()
-def get_hstore_oids(connection_alias):
-    """Return hstore and hstore array OIDs."""
+def get_type_oids(connection_alias, type_name):
     with connections[connection_alias].cursor() as cursor:
         cursor.execute(
-            "SELECT t.oid, typarray "
-            "FROM pg_type t "
-            "JOIN pg_namespace ns ON typnamespace = ns.oid "
-            "WHERE typname = 'hstore'"
+            "SELECT oid, typarray FROM pg_type WHERE typname = %s", (type_name,)
         )
         oids = []
         array_oids = []
@@ -26,39 +18,63 @@ def get_hstore_oids(connection_alias):
         return tuple(oids), tuple(array_oids)
 
 
-@functools.lru_cache()
+@functools.lru_cache
+def get_hstore_oids(connection_alias):
+    """Return hstore and hstore array OIDs."""
+    return get_type_oids(connection_alias, "hstore")
+
+
+@functools.lru_cache
 def get_citext_oids(connection_alias):
-    """Return citext array OIDs."""
-    with connections[connection_alias].cursor() as cursor:
-        cursor.execute("SELECT typarray FROM pg_type WHERE typname = 'citext'")
-        return tuple(row[0] for row in cursor)
+    """Return citext and citext array OIDs."""
+    return get_type_oids(connection_alias, "citext")
 
 
-def register_type_handlers(connection, **kwargs):
-    if connection.vendor != 'postgresql' or connection.alias == NO_DB_ALIAS:
-        return
+if is_psycopg3:
+    from psycopg.types import TypeInfo, hstore
 
-    try:
+    def register_type_handlers(connection, **kwargs):
+        if connection.vendor != "postgresql" or connection.alias == NO_DB_ALIAS:
+            return
+
         oids, array_oids = get_hstore_oids(connection.alias)
-        register_hstore(connection.connection, globally=True, oid=oids, array_oid=array_oids)
-    except ProgrammingError:
-        # Hstore is not available on the database.
-        #
-        # If someone tries to create an hstore field it will error there.
-        # This is necessary as someone may be using PSQL without extensions
-        # installed but be using other features of contrib.postgres.
-        #
-        # This is also needed in order to create the connection in order to
-        # install the hstore extension.
-        pass
+        for oid, array_oid in zip(oids, array_oids):
+            ti = TypeInfo("hstore", oid, array_oid)
+            hstore.register_hstore(ti, connection.connection)
 
-    try:
-        citext_oids = get_citext_oids(connection.alias)
-        array_type = psycopg2.extensions.new_array_type(citext_oids, 'citext[]', psycopg2.STRING)
-        psycopg2.extensions.register_type(array_type, None)
-    except ProgrammingError:
-        # citext is not available on the database.
+        _, citext_oids = get_citext_oids(connection.alias)
+        for array_oid in citext_oids:
+            ti = TypeInfo("citext", 0, array_oid)
+            ti.register(connection.connection)
+
+else:
+    import psycopg2
+    from psycopg2.extras import register_hstore
+
+    def register_type_handlers(connection, **kwargs):
+        if connection.vendor != "postgresql" or connection.alias == NO_DB_ALIAS:
+            return
+
+        oids, array_oids = get_hstore_oids(connection.alias)
+        # Don't register handlers when hstore is not available on the database.
         #
-        # The same comments in the except block of the above call to
-        # register_hstore() also apply here.
-        pass
+        # If someone tries to create an hstore field it will error there. This is
+        # necessary as someone may be using PSQL without extensions installed but
+        # be using other features of contrib.postgres.
+        #
+        # This is also needed in order to create the connection in order to install
+        # the hstore extension.
+        if oids:
+            register_hstore(
+                connection.connection, globally=True, oid=oids, array_oid=array_oids
+            )
+
+        oids, citext_oids = get_citext_oids(connection.alias)
+        # Don't register handlers when citext is not available on the database.
+        #
+        # The same comments in the above call to register_hstore() also apply here.
+        if oids:
+            array_type = psycopg2.extensions.new_array_type(
+                citext_oids, "citext[]", psycopg2.STRING
+            )
+            psycopg2.extensions.register_type(array_type, None)

--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -162,6 +162,8 @@ class BaseDatabaseFeatures:
     # Can we roll back DDL in a transaction?
     can_rollback_ddl = False
 
+    schema_editor_uses_clientside_param_binding = False
+
     # Does it support operations requiring references rename in a transaction?
     supports_atomic_references_rename = True
 
@@ -318,6 +320,9 @@ class BaseDatabaseFeatures:
     supports_collation_on_textfield = True
     # Does the backend support non-deterministic collations?
     supports_non_deterministic_collations = True
+
+    # Set to (exception, message) if null characters in text are disallowed.
+    prohibits_null_characters_in_text_exception = None
 
     # Collation names for use by the Django test suite.
     test_collations = {

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -486,6 +486,9 @@ class BaseDatabaseOperations:
         else:
             return value
 
+    def adapt_integerfield_value(self, value, internal_type):
+        return value
+
     def adapt_datefield_value(self, value):
         """
         Transform a date value to an object compatible with what is expected

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -1,7 +1,7 @@
 """
 PostgreSQL database backend for Django.
 
-Requires psycopg 2: https://www.psycopg.org/
+Requires psycopg2 >= 2.8.4 or psycopg >= 3.1
 """
 
 import asyncio
@@ -22,44 +22,63 @@ from django.utils.safestring import SafeString
 from django.utils.version import get_version_tuple
 
 try:
-    import psycopg2 as Database
-    import psycopg2.extensions
-    import psycopg2.extras
-except ImportError as e:
-    raise ImproperlyConfigured("Error loading psycopg2 module: %s" % e)
+    try:
+        import psycopg as Database
+    except ImportError:
+        import psycopg2 as Database
+except ImportError:
+    raise ImproperlyConfigured("Error loading psycopg2 or psycopg module")
 
 
-def psycopg2_version():
-    version = psycopg2.__version__.split(' ', 1)[0]
+def psycopg_version():
+    version = Database.__version__.split(" ", 1)[0]
     return get_version_tuple(version)
 
 
-PSYCOPG2_VERSION = psycopg2_version()
+if psycopg_version() < (2, 8, 4):
+    raise ImproperlyConfigured(
+        f"psycopg2 version 2.8.4 or newer is required; you have {Database.__version__}"
+    )
+if (3,) <= psycopg_version() < (3, 1):
+    raise ImproperlyConfigured(
+        f"psycopg version 3.1 or newer is required; you have {Database.__version__}"
+    )
 
-if PSYCOPG2_VERSION < (2, 5, 4):
-    raise ImproperlyConfigured("psycopg2_version 2.5.4 or newer is required; you have %s" % psycopg2.__version__)
 
+from .psycopg_any import IsolationLevel, is_psycopg3  # NOQA isort:skip
 
-# Some of these import psycopg2, so import them after checking if it's installed.
-from .client import DatabaseClient  # NOQA
-from .creation import DatabaseCreation  # NOQA
-from .features import DatabaseFeatures  # NOQA
-from .introspection import DatabaseIntrospection  # NOQA
-from .operations import DatabaseOperations  # NOQA
-from .schema import DatabaseSchemaEditor  # NOQA
+if is_psycopg3:
+    from psycopg import adapters, sql
+    from psycopg.pq import Format
 
-psycopg2.extensions.register_adapter(SafeString, psycopg2.extensions.QuotedString)
-psycopg2.extras.register_uuid()
+    from .psycopg_any import get_adapters_template, register_tzloader
 
-# Register support for inet[] manually so we don't have to handle the Inet()
-# object on load all the time.
-INETARRAY_OID = 1041
-INETARRAY = psycopg2.extensions.new_array_type(
-    (INETARRAY_OID,),
-    'INETARRAY',
-    psycopg2.extensions.UNICODE,
-)
-psycopg2.extensions.register_type(INETARRAY)
+    TIMESTAMPTZ_OID = adapters.types["timestamptz"].oid
+
+else:
+    import psycopg2.extensions
+    import psycopg2.extras
+
+    psycopg2.extensions.register_adapter(SafeString, psycopg2.extensions.QuotedString)
+    psycopg2.extras.register_uuid()
+
+    # Register support for inet[] manually so we don't have to handle the Inet()
+    # object on load all the time.
+    INETARRAY_OID = 1041
+    INETARRAY = psycopg2.extensions.new_array_type(
+        (INETARRAY_OID,),
+        "INETARRAY",
+        psycopg2.extensions.UNICODE,
+    )
+    psycopg2.extensions.register_type(INETARRAY)
+
+# Some of these import psycopg, so import them after checking if it's installed.
+from .client import DatabaseClient  # NOQA isort:skip
+from .creation import DatabaseCreation  # NOQA isort:skip
+from .features import DatabaseFeatures  # NOQA isort:skip
+from .introspection import DatabaseIntrospection  # NOQA isort:skip
+from .operations import DatabaseOperations  # NOQA isort:skip
+from .schema import DatabaseSchemaEditor  # NOQA isort:skip
 
 
 class DatabaseWrapper(BaseDatabaseWrapper):
@@ -167,19 +186,37 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                     self.ops.max_name_length(),
                 )
             )
-        conn_params = {
-            'database': settings_dict['NAME'] or 'postgres',
-            **settings_dict['OPTIONS'],
-        }
-        conn_params.pop('isolation_level', None)
-        if settings_dict['USER']:
-            conn_params['user'] = settings_dict['USER']
-        if settings_dict['PASSWORD']:
-            conn_params['password'] = settings_dict['PASSWORD']
-        if settings_dict['HOST']:
-            conn_params['host'] = settings_dict['HOST']
-        if settings_dict['PORT']:
-            conn_params['port'] = settings_dict['PORT']
+        conn_params = {"client_encoding": "UTF8"}
+        if settings_dict["NAME"]:
+            conn_params = {
+                "dbname": settings_dict["NAME"],
+                **settings_dict["OPTIONS"],
+            }
+        elif settings_dict["NAME"] is None:
+            # Connect to the default 'postgres' db.
+            settings_dict.get("OPTIONS", {}).pop("service", None)
+            conn_params = {"dbname": "postgres", **settings_dict["OPTIONS"]}
+        else:
+            conn_params = {**settings_dict["OPTIONS"]}
+
+        conn_params.pop("isolation_level", None)
+        if settings_dict["USER"]:
+            conn_params["user"] = settings_dict["USER"]
+        if settings_dict["PASSWORD"]:
+            conn_params["password"] = settings_dict["PASSWORD"]
+        if settings_dict["HOST"]:
+            conn_params["host"] = settings_dict["HOST"]
+        if settings_dict["PORT"]:
+            conn_params["port"] = settings_dict["PORT"]
+        if is_psycopg3:
+            conn_params["context"] = get_adapters_template(
+                settings.USE_TZ, self.timezone
+            )
+            # Disable prepared statements by default to keep connection poolers
+            # working. Can be reenabled via OPTIONS in the settings dict.
+            conn_params["prepare_threshold"] = conn_params.pop(
+                "prepare_threshold", None
+            )
         return conn_params
 
     @async_unsafe
@@ -191,25 +228,39 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         #   default when no value is explicitly specified in options.
         # - before calling _set_autocommit() because if autocommit is on, that
         #   will set connection.isolation_level to ISOLATION_LEVEL_AUTOCOMMIT.
-        options = self.settings_dict['OPTIONS']
+        options = self.settings_dict["OPTIONS"]
+        set_isolation_level = False
         try:
-            self.isolation_level = options['isolation_level']
+            isolation_level_value = options["isolation_level"]
         except KeyError:
-            self.isolation_level = connection.isolation_level
+            self.isolation_level = IsolationLevel.READ_COMMITTED
         else:
             # Set the isolation level to the value from OPTIONS.
-            if self.isolation_level != connection.isolation_level:
-                connection.set_session(isolation_level=self.isolation_level)
-        # Register dummy loads() to avoid a round trip from psycopg2's decode
-        # to json.dumps() to json.loads(), when using a custom decoder in
-        # JSONField.
-        psycopg2.extras.register_default_jsonb(conn_or_curs=connection, loads=lambda x: x)
+            try:
+                self.isolation_level = IsolationLevel(isolation_level_value)
+                set_isolation_level = True
+            except ValueError:
+                raise ImproperlyConfigured(
+                    f"Invalid transaction isolation level {isolation_level_value} "
+                    f"specified. Use one of the psycopg.IsolationLevel values."
+                )
+        connection = self.Database.connect(**conn_params)
+        if set_isolation_level:
+            connection.isolation_level = self.isolation_level
+        if not is_psycopg3:
+            # Register dummy loads() to avoid a round trip from psycopg2's
+            # decode to json.dumps() to json.loads(), when using a custom
+            # decoder in JSONField.
+            psycopg2.extras.register_default_jsonb(
+                conn_or_curs=connection, loads=lambda x: x
+            )
+        connection.cursor_factory = Cursor
         return connection
 
     def ensure_timezone(self):
         if self.connection is None:
             return False
-        conn_timezone_name = self.connection.get_parameter_status('TimeZone')
+        conn_timezone_name = self.connection.info.parameter_status("TimeZone")
         timezone_name = self.timezone_name
         if timezone_name and conn_timezone_name != timezone_name:
             with self.connection.cursor() as cursor:
@@ -234,7 +285,15 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             cursor = self.connection.cursor(name, scrollable=False, withhold=self.connection.autocommit)
         else:
             cursor = self.connection.cursor()
-        cursor.tzinfo_factory = self.tzinfo_factory if settings.USE_TZ else None
+
+        if is_psycopg3:
+            # Register the cursor timezone only if the connection disagrees, to
+            # avoid copying the adapter map.
+            tzloader = self.connection.adapters.get_loader(TIMESTAMPTZ_OID, Format.TEXT)
+            if self.timezone != tzloader.timezone:
+                register_tzloader(self.timezone, cursor)
+        else:
+            cursor.tzinfo_factory = self.tzinfo_factory if settings.USE_TZ else None
         return cursor
 
     def tzinfo_factory(self, offset):
@@ -333,11 +392,43 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return CursorDebugWrapper(cursor, self)
 
 
-class CursorDebugWrapper(BaseCursorDebugWrapper):
-    def copy_expert(self, sql, file, *args):
-        with self.debug_sql(sql):
-            return self.cursor.copy_expert(sql, file, *args)
+if is_psycopg3:
 
-    def copy_to(self, file, table, *args, **kwargs):
-        with self.debug_sql(sql='COPY %s TO STDOUT' % table):
-            return self.cursor.copy_to(file, table, *args, **kwargs)
+    class Cursor(Database.Cursor):
+        """
+        A subclass of psycopg cursor implementing callproc.
+        """
+
+        def callproc(self, name, args=None):
+            if not isinstance(name, sql.Identifier):
+                name = sql.Identifier(name)
+
+            qparts = [sql.SQL("SELECT * FROM "), name, sql.SQL("(")]
+            if args:
+                for item in args:
+                    qparts.append(sql.Literal(item))
+                    qparts.append(sql.SQL(","))
+                del qparts[-1]
+
+            qparts.append(sql.SQL(")"))
+            stmt = sql.Composed(qparts)
+            self.execute(stmt)
+            return args
+
+    class CursorDebugWrapper(BaseCursorDebugWrapper):
+        def copy(self, statement):
+            with self.debug_sql(statement):
+                return self.cursor.copy(statement)
+
+else:
+
+    Cursor = psycopg2.extensions.cursor
+
+    class CursorDebugWrapper(BaseCursorDebugWrapper):
+        def copy_expert(self, sql, file, *args):
+            with self.debug_sql(sql):
+                return self.cursor.copy_expert(sql, file, *args)
+
+        def copy_to(self, file, table, *args, **kwargs):
+            with self.debug_sql(sql="COPY %s TO STDOUT" % table):
+                return self.cursor.copy_to(file, table, *args, **kwargs)

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -1,7 +1,8 @@
 import operator
 
-from django.db import InterfaceError
+from django.db import DataError, InterfaceError
 from django.db.backends.base.features import BaseDatabaseFeatures
+from django.db.backends.postgresql.psycopg_any import is_psycopg3
 from django.utils.functional import cached_property
 
 
@@ -25,6 +26,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_introspect_materialized_views = True
     can_distinct_on_fields = True
     can_rollback_ddl = True
+    schema_editor_uses_clientside_param_binding = True
     supports_combined_alters = True
     nulls_order_largest = True
     closed_cursor_error_class = InterfaceError
@@ -73,6 +75,13 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                 'swedish_ci': 'sv-x-icu',
             }
         return {}
+
+    @cached_property
+    def prohibits_null_characters_in_text_exception(self):
+        if is_psycopg3:
+            return DataError, "PostgreSQL text fields cannot contain NUL (0x00) bytes"
+        else:
+            return ValueError, "A string literal cannot contain NUL (0x00) characters."
 
     @cached_property
     def introspected_field_types(self):

--- a/django/db/backends/postgresql/psycopg_any.py
+++ b/django/db/backends/postgresql/psycopg_any.py
@@ -1,0 +1,102 @@
+import ipaddress
+from functools import lru_cache
+
+try:
+    from psycopg import ClientCursor, IsolationLevel, adapt, adapters, errors, sql
+    from psycopg.postgres import types
+    from psycopg.types.datetime import TimestamptzLoader
+    from psycopg.types.json import Jsonb
+    from psycopg.types.range import Range, RangeDumper
+    from psycopg.types.string import TextLoader
+
+    Inet = ipaddress.ip_address
+
+    DateRange = DateTimeRange = DateTimeTZRange = NumericRange = Range
+    RANGE_TYPES = (Range,)
+
+    TSRANGE_OID = types["tsrange"].oid
+    TSTZRANGE_OID = types["tstzrange"].oid
+
+    def mogrify(sql, params, connection):
+        return ClientCursor(connection.connection).mogrify(sql, params)
+
+    # Adapters.
+    class BaseTzLoader(TimestamptzLoader):
+        """
+        Load a PostgreSQL timestamptz using the a specific timezone.
+        The timezone can be None too, in which case it will be chopped.
+        """
+
+        timezone = None
+
+        def load(self, data):
+            res = super().load(data)
+            return res.replace(tzinfo=self.timezone)
+
+    def register_tzloader(tz, context):
+        class SpecificTzLoader(BaseTzLoader):
+            timezone = tz
+
+        context.adapters.register_loader("timestamptz", SpecificTzLoader)
+
+    class DjangoRangeDumper(RangeDumper):
+        """A Range dumper customized for Django."""
+
+        def upgrade(self, obj, format):
+            # Dump ranges containing naive datetimes as tstzrange, because
+            # Django doesn't use tz-aware ones.
+            dumper = super().upgrade(obj, format)
+            if dumper is not self and dumper.oid == TSRANGE_OID:
+                dumper.oid = TSTZRANGE_OID
+            return dumper
+
+    @lru_cache
+    def get_adapters_template(use_tz, timezone):
+        # Create at adapters map extending the base one.
+        ctx = adapt.AdaptersMap(adapters)
+        # Register a no-op dumper to avoid a round trip from psycopg version 3
+        # decode to json.dumps() to json.loads(), when using a custom decoder
+        # in JSONField.
+        ctx.register_loader("jsonb", TextLoader)
+        # Don't convert automatically from PostgreSQL network types to Python
+        # ipaddress.
+        ctx.register_loader("inet", TextLoader)
+        ctx.register_loader("cidr", TextLoader)
+        ctx.register_dumper(Range, DjangoRangeDumper)
+        # Register a timestamptz loader configured on self.timezone.
+        # This, however, can be overridden by create_cursor.
+        register_tzloader(timezone, ctx)
+        return ctx
+
+    is_psycopg3 = True
+
+except ImportError:
+    from enum import IntEnum
+
+    from psycopg2 import errors, extensions, sql  # NOQA
+    from psycopg2.extras import DateRange, DateTimeRange, DateTimeTZRange, Inet  # NOQA
+    from psycopg2.extras import Json as Jsonb  # NOQA
+    from psycopg2.extras import NumericRange, Range  # NOQA
+
+    RANGE_TYPES = (DateRange, DateTimeRange, DateTimeTZRange, NumericRange)
+
+    class IsolationLevel(IntEnum):
+        READ_UNCOMMITTED = extensions.ISOLATION_LEVEL_READ_UNCOMMITTED
+        READ_COMMITTED = extensions.ISOLATION_LEVEL_READ_COMMITTED
+        REPEATABLE_READ = extensions.ISOLATION_LEVEL_REPEATABLE_READ
+        SERIALIZABLE = extensions.ISOLATION_LEVEL_SERIALIZABLE
+
+    def _quote(value, connection=None):
+        adapted = extensions.adapt(value)
+        if hasattr(adapted, "encoding"):
+            adapted.encoding = "utf8"
+        # getquoted() returns a quoted bytestring of the adapted value.
+        return adapted.getquoted().decode()
+
+    sql.quote = _quote
+
+    def mogrify(sql, params, connection):
+        with connection.cursor() as cursor:
+            return cursor.mogrify(sql, params).decode()
+
+    is_psycopg3 = False

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1826,6 +1826,10 @@ class IntegerField(Field):
                 "Field '%s' expected a number but got %r." % (self.name, value),
             ) from e
 
+    def get_db_prep_value(self, value, connection, prepared=False):
+        value = super().get_db_prep_value(value, connection, prepared)
+        return connection.ops.adapt_integerfield_value(value, self.get_internal_type())
+
     def get_internal_type(self):
         return "IntegerField"
 

--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -1,6 +1,7 @@
 """Database functions that do comparisons or type conversions."""
 from django.db import NotSupportedError
 from django.db.models.expressions import Func, Value
+from django.db.models.fields import TextField
 from django.db.models.fields.json import JSONField
 from django.utils.regex_helper import _lazy_re_compile
 
@@ -126,7 +127,14 @@ class JSONObject(Func):
         return super().as_sql(compiler, connection, **extra_context)
 
     def as_postgresql(self, compiler, connection, **extra_context):
-        return self.as_sql(
+        copy = self.copy()
+        copy.set_source_expressions(
+            [
+                Cast(expression, TextField()) if index % 2 == 0 else expression
+                for index, expression in enumerate(copy.get_source_expressions())
+            ]
+        )
+        return super(JSONObject, copy).as_sql(
             compiler,
             connection,
             function='JSONB_BUILD_OBJECT',

--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -1,7 +1,7 @@
 from django.db import NotSupportedError
 from django.db.models.expressions import Func, Value
-from django.db.models.fields import CharField, IntegerField
-from django.db.models.functions import Coalesce
+from django.db.models.fields import CharField, IntegerField, TextField
+from django.db.models.functions import Cast, Coalesce
 from django.db.models.lookups import Transform
 
 
@@ -73,6 +73,20 @@ class ConcatPair(Func):
         return super(ConcatPair, coalesced).as_sql(
             compiler, connection, template='%(expressions)s', arg_joiner=' || ',
             **extra_context
+        )
+
+    def as_postgresql(self, compiler, connection, **extra_context):
+        copy = self.copy()
+        copy.set_source_expressions(
+            [
+                Cast(expression, TextField())
+                for expression in copy.get_source_expressions()
+            ]
+        )
+        return super(ConcatPair, copy).as_sql(
+            compiler,
+            connection,
+            **extra_context,
         )
 
     def as_mysql(self, compiler, connection, **extra_context):

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -518,7 +518,7 @@ class IsNull(BuiltinLookup):
                 'deprecated, use True or False instead.',
                 RemovedInDjango40Warning,
             )
-        sql, params = compiler.compile(self.lhs)
+        sql, params = self.process_lhs(compiler, connection)
         if self.rhs:
             return "%s IS NULL" % sql, params
         else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,7 +153,7 @@ pygments_style = 'trac'
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
-    'psycopg2': ('https://www.psycopg.org/docs/', None),
+    'psycopg': ('https://www.psycopg.org/psycopg3/docs/', None),
 }
 
 # Python's docs don't change every week.

--- a/docs/ref/contrib/gis/install/index.txt
+++ b/docs/ref/contrib/gis/install/index.txt
@@ -487,14 +487,14 @@ Install Django and set up database
 recommended that you create a :doc:`virtural environment
 <python:tutorial/venv>` for each project you create.
 
-psycopg2
-~~~~~~~~
+psycopg
+~~~~~~~
 
-The ``psycopg2`` Python module provides the interface between Python and the
-PostgreSQL database. ``psycopg2`` can be installed via pip within your Python
+The ``psycopg`` Python module provides the interface between Python and the
+PostgreSQL database. ``psycopg`` can be installed via pip within your Python
 virtual environment::
 
-    ...\> py -m pip install psycopg2
+    ...\> py -m pip install psycopg
 
 .. rubric:: Footnotes
 .. [#] GeoDjango uses the :func:`~ctypes.util.find_library` routine from

--- a/docs/ref/contrib/gis/install/postgis.txt
+++ b/docs/ref/contrib/gis/install/postgis.txt
@@ -7,19 +7,24 @@ into a spatial database. :ref:`geosbuild`, :ref:`proj4` and
 :ref:`gdalbuild` should be installed prior to building PostGIS. You
 might also need additional libraries, see `PostGIS requirements`_.
 
-The `psycopg2`_ module is required for use as the database adapter when using
-GeoDjango with PostGIS.
+The `psycopg`_ or `psycopg2`_ module is required for use as the database
+adapter when using GeoDjango with PostGIS.
 
 On Debian/Ubuntu, you are advised to install the following packages:
-postgresql-x.x, postgresql-x.x-postgis, postgresql-server-dev-x.x,
-python-psycopg2 (x.x matching the PostgreSQL version you want to install).
-Alternately, you can `build from source`_. Consult the platform-specific
-instructions if you are on :ref:`macos` or :ref:`windows`.
+``postgresql-x``, ``postgresql-x-postgis-3``, ``postgresql-server-dev-x``,
+and ``python3-psycopg3`` (x matching the PostgreSQL version you want to
+install). Alternately, you can `build from source`_. Consult the
+platform-specific instructions if you are on :ref:`macos` or :ref:`windows`.
 
 .. _PostGIS: https://postgis.net/
+.. _psycopg: https://www.psycopg.org/psycopg3/
 .. _psycopg2: https://www.psycopg.org/
 .. _PostGIS requirements: https://postgis.net/docs/postgis_installation.html#install_requirements
 .. _build from source: https://postgis.net/docs/postgis_installation.html#install_short_version
+
+.. versionchanged:: 3.2
+
+    Support for ``psycopg`` 3.1+ was added.
 
 Post-installation
 =================

--- a/docs/ref/contrib/postgres/forms.txt
+++ b/docs/ref/contrib/postgres/forms.txt
@@ -192,7 +192,7 @@ not greater than the upper bound. All of these fields use
 .. class:: IntegerRangeField
 
     Based on :class:`~django.forms.IntegerField` and translates its input into
-    :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
+    ``django.db.backends.postgresql.psycopg_any.NumericRange``. Default for
     :class:`~django.contrib.postgres.fields.IntegerRangeField` and
     :class:`~django.contrib.postgres.fields.BigIntegerRangeField`.
 
@@ -202,7 +202,7 @@ not greater than the upper bound. All of these fields use
 .. class:: DecimalRangeField
 
     Based on :class:`~django.forms.DecimalField` and translates its input into
-    :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
+    ``django.db.backends.postgresql.psycopg_any.NumericRange``. Default for
     :class:`~django.contrib.postgres.fields.DecimalRangeField`.
 
 ``DateTimeRangeField``
@@ -211,7 +211,7 @@ not greater than the upper bound. All of these fields use
 .. class:: DateTimeRangeField
 
     Based on :class:`~django.forms.DateTimeField` and translates its input into
-    :class:`~psycopg2:psycopg2.extras.DateTimeTZRange`. Default for
+    ``django.db.backends.postgresql.psycopg_any.DateTimeTZRange``. Default for
     :class:`~django.contrib.postgres.fields.DateTimeRangeField`.
 
 ``DateRangeField``
@@ -220,7 +220,7 @@ not greater than the upper bound. All of these fields use
 .. class:: DateRangeField
 
     Based on :class:`~django.forms.DateField` and translates its input into
-    :class:`~psycopg2:psycopg2.extras.DateRange`. Default for
+    ``django.db.backends.postgresql.psycopg_any.DateRange``. Default for
     :class:`~django.contrib.postgres.fields.DateRangeField`.
 
 Widgets

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -103,10 +103,17 @@ below for information on how to set up your database correctly.
 PostgreSQL notes
 ================
 
-Django supports PostgreSQL 9.6 and higher. `psycopg2`_ 2.5.4 or higher is
-required, though the latest release is recommended.
+Django supports PostgreSQL 12 and higher. `psycopg`_ 3.1+ or `psycopg2`_ 2.8.4+
+is required, though the latest `psycopg`_ 3.1+ is recommended.
 
+.. _psycopg: https://www.psycopg.org/psycopg3/
 .. _psycopg2: https://www.psycopg.org/
+
+.. versionchanged:: 3.2
+
+    Support for ``psycopg`` 3.1+ was added.
+
+.. _postgresql-connection-settings:
 
 PostgreSQL connection settings
 -------------------------------
@@ -147,12 +154,12 @@ level`_. If you need a higher isolation level such as ``REPEATABLE READ`` or
 ``SERIALIZABLE``, set it in the :setting:`OPTIONS` part of your database
 configuration in :setting:`DATABASES`::
 
-    import psycopg2.extensions
+    from django.db.backends.postgresql.psycopg_any import IsolationLevel
 
     DATABASES = {
         # ...
         'OPTIONS': {
-            'isolation_level': psycopg2.extensions.ISOLATION_LEVEL_SERIALIZABLE,
+            'isolation_level': IsolationLevel.SERIALIZABLE,
         },
     }
 
@@ -163,6 +170,10 @@ configuration in :setting:`DATABASES`::
     designed for advanced uses.
 
 .. _isolation level: https://www.postgresql.org/docs/current/transaction-iso.html
+
+.. versionchanged:: 3.2
+
+    ``IsolationLevel`` was added.
 
 Indexes for ``varchar`` and ``text`` columns
 --------------------------------------------
@@ -192,7 +203,7 @@ Server-side cursors
 
 When using :meth:`QuerySet.iterator()
 <django.db.models.query.QuerySet.iterator>`, Django opens a :ref:`server-side
-cursor <psycopg2:server-side-cursors>`. By default, PostgreSQL assumes that
+cursor <psycopg:server-side-cursors>`. By default, PostgreSQL assumes that
 only the first 10% of the results of cursor queries will be fetched. The query
 planner spends less time planning the query and starts returning results
 faster, but this could diminish performance if more than 10% of the results are

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -256,10 +256,11 @@ Database backends
 * Added the :setting:`TEST['TEMPLATE'] <TEST_TEMPLATE>` setting to let
   PostgreSQL users specify a template for creating the test database.
 
-* :meth:`.QuerySet.iterator()` now uses :ref:`server-side cursors
-  <psycopg2:server-side-cursors>` on PostgreSQL. This feature transfers some of
-  the worker memory load (used to hold query results) to the database and might
-  increase database memory usage.
+* :meth:`.QuerySet.iterator()` now uses `server-side cursors`_ on PostgreSQL.
+  This feature transfers some of the worker memory load (used to hold query
+  results) to the database and might increase database memory usage.
+
+  .. _server-side cursors: https://www.psycopg.org/docs/usage.html#server-side-cursors
 
 * Added MySQL support for the ``'isolation_level'`` option in
   :setting:`OPTIONS` to allow specifying the :ref:`transaction isolation level

--- a/docs/topics/db/transactions.txt
+++ b/docs/topics/db/transactions.txt
@@ -385,8 +385,8 @@ etc.), this should be fine. If it's not (if your follow-up action is so
 critical that its failure should mean the failure of the transaction itself),
 then you don't want to use the :func:`on_commit` hook. Instead, you may want
 `two-phase commit`_ such as the :ref:`psycopg Two-Phase Commit protocol support
-<psycopg2:tpc>` and the :pep:`optional Two-Phase Commit Extensions in the
-Python DB-API specification <249#optional-two-phase-commit-extensions>`.
+<psycopg:two-phase-commit>` and the :pep:`optional Two-Phase Commit Extensions
+in the Python DB-API specification <249#optional-two-phase-commit-extensions>`.
 
 Callbacks are not run until autocommit is restored on the connection following
 the commit (because otherwise any queries done in a callback would open an

--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -79,8 +79,9 @@ databases with Django.
 In addition to a database backend, you'll need to make sure your Python
 database bindings are installed.
 
-* If you're using PostgreSQL, you'll need the `psycopg2`_ package. Refer to the
-  :ref:`PostgreSQL notes <postgresql-notes>` for further details.
+* If you're using PostgreSQL, you'll need the `psycopg`_ or `psycopg2`_
+  package. Refer to the :ref:`PostgreSQL notes <postgresql-notes>` for further
+  details.
 
 * If you're using MySQL or MariaDB, you'll need a :ref:`DB API driver
   <mysql-db-api-drivers>` like ``mysqlclient``. See :ref:`notes for the MySQL
@@ -111,6 +112,7 @@ database queries, Django will need permission to create a test database.
 .. _PostgreSQL: https://www.postgresql.org/
 .. _MariaDB: https://mariadb.org/
 .. _MySQL: https://www.mysql.com/
+.. _psycopg: https://www.psycopg.org/psycopg3/
 .. _psycopg2: https://www.psycopg.org/
 .. _SQLite: https://www.sqlite.org/
 .. _cx_Oracle: https://oracle.github.io/python-cx_Oracle/

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -8,6 +8,11 @@ from django.db import DEFAULT_DB_ALIAS, DatabaseError, connection, connections
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.test import TestCase, override_settings
 
+try:
+    from django.db.backends.postgresql.psycopg_any import is_psycopg3
+except ImportError:
+    is_psycopg3 = False
+
 
 @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL tests')
 class Tests(TestCase):
@@ -172,28 +177,39 @@ class Tests(TestCase):
         The transaction level can be configured with
         DATABASES ['OPTIONS']['isolation_level'].
         """
-        import psycopg2
-        from psycopg2.extensions import (
-            ISOLATION_LEVEL_READ_COMMITTED as read_committed,
-            ISOLATION_LEVEL_SERIALIZABLE as serializable,
-        )
+        from django.db.backends.postgresql.psycopg_any import IsolationLevel
 
         # Since this is a django.test.TestCase, a transaction is in progress
         # and the isolation level isn't reported as 0. This test assumes that
         # PostgreSQL is configured with the default isolation level.
-        # Check the level on the psycopg2 connection, not the Django wrapper.
-        default_level = read_committed if psycopg2.__version__ < '2.7' else None
-        self.assertEqual(connection.connection.isolation_level, default_level)
+        # Check the level on the psycopg connection, not the Django wrapper.
+        self.assertIsNone(connection.connection.isolation_level)
 
         new_connection = connection.copy()
-        new_connection.settings_dict['OPTIONS']['isolation_level'] = serializable
+        new_connection.settings_dict["OPTIONS"][
+            "isolation_level"
+        ] = IsolationLevel.SERIALIZABLE
         try:
             # Start a transaction so the isolation level isn't reported as 0.
             new_connection.set_autocommit(False)
-            # Check the level on the psycopg2 connection, not the Django wrapper.
-            self.assertEqual(new_connection.connection.isolation_level, serializable)
+            # Check the level on the psycopg connection, not the Django wrapper.
+            self.assertEqual(
+                new_connection.connection.isolation_level,
+                IsolationLevel.SERIALIZABLE,
+            )
         finally:
             new_connection.close()
+
+    def test_connect_invalid_isolation_level(self):
+        self.assertIsNone(connection.connection.isolation_level)
+        new_connection = connection.copy()
+        new_connection.settings_dict["OPTIONS"]["isolation_level"] = -1
+        msg = (
+            "Invalid transaction isolation level -1 specified. Use one of the "
+            "psycopg.IsolationLevel values."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            new_connection.ensure_connection()
 
     def test_connect_no_is_usable_checks(self):
         new_connection = connection.copy()
@@ -206,7 +222,7 @@ class Tests(TestCase):
 
     def _select(self, val):
         with connection.cursor() as cursor:
-            cursor.execute('SELECT %s', (val,))
+            cursor.execute("SELECT %s::text[]", (val,))
             return cursor.fetchone()[0]
 
     def test_select_ascii_array(self):
@@ -234,15 +250,19 @@ class Tests(TestCase):
                 with self.subTest(lookup=lookup, field_type=field_type):
                     self.assertIn('::citext', do.lookup_cast(lookup, internal_type=field_type))
 
-    def test_correct_extraction_psycopg2_version(self):
-        from django.db.backends.postgresql.base import psycopg2_version
-        with mock.patch('psycopg2.__version__', '4.2.1 (dt dec pq3 ext lo64)'):
-            self.assertEqual(psycopg2_version(), (4, 2, 1))
-        with mock.patch('psycopg2.__version__', '4.2b0.dev1 (dt dec pq3 ext lo64)'):
-            self.assertEqual(psycopg2_version(), (4, 2))
+    def test_correct_extraction_psycopg_version(self):
+        from django.db.backends.postgresql.base import Database, psycopg_version
+
+        with mock.patch.object(Database, "__version__", "4.2.1 (dt dec pq3 ext lo64)"):
+            self.assertEqual(psycopg_version(), (4, 2, 1))
+        with mock.patch.object(
+            Database, "__version__", "4.2b0.dev1 (dt dec pq3 ext lo64)"
+        ):
+            self.assertEqual(psycopg_version(), (4, 2))
 
     @override_settings(DEBUG=True)
-    def test_copy_cursors(self):
+    @unittest.skipIf(is_psycopg3, "psycopg2 specific test")
+    def test_copy_to_expert_cursors(self):
         out = StringIO()
         copy_expert_sql = 'COPY django_session TO STDOUT (FORMAT CSV, HEADER)'
         with connection.cursor() as cursor:
@@ -252,3 +272,13 @@ class Tests(TestCase):
             [q['sql'] for q in connection.queries],
             [copy_expert_sql, 'COPY django_session TO STDOUT'],
         )
+
+    @override_settings(DEBUG=True)
+    @unittest.skipUnless(is_psycopg3, "psycopg3 specific test")
+    def test_copy_cursors(self):
+        copy_sql = "COPY django_session TO STDOUT (FORMAT CSV, HEADER)"
+        with connection.cursor() as cursor:
+            with cursor.copy(copy_sql) as copy:
+                for row in copy:
+                    pass
+        self.assertEqual([q["sql"] for q in connection.queries], [copy_sql])

--- a/tests/db_utils/tests.py
+++ b/tests/db_utils/tests.py
@@ -68,14 +68,20 @@ class DatabaseErrorWrapperTests(TestCase):
 
     @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL test')
     def test_reraising_backend_specific_database_exception(self):
+        from django.db.backends.postgresql.psycopg_any import is_psycopg3
+
         with connection.cursor() as cursor:
             msg = 'table "X" does not exist'
             with self.assertRaisesMessage(ProgrammingError, msg) as cm:
                 cursor.execute('DROP TABLE "X"')
         self.assertNotEqual(type(cm.exception), type(cm.exception.__cause__))
         self.assertIsNotNone(cm.exception.__cause__)
-        self.assertIsNotNone(cm.exception.__cause__.pgcode)
-        self.assertIsNotNone(cm.exception.__cause__.pgerror)
+        if is_psycopg3:
+            self.assertIsNotNone(cm.exception.__cause__.diag.sqlstate)
+            self.assertIsNotNone(cm.exception.__cause__.diag.message_primary)
+        else:
+            self.assertIsNotNone(cm.exception.__cause__.pgcode)
+            self.assertIsNotNone(cm.exception.__cause__.pgerror)
 
 
 class LoadBackendTests(SimpleTestCase):

--- a/tests/gis_tests/tests.py
+++ b/tests/gis_tests/tests.py
@@ -36,7 +36,7 @@ if HAS_POSTGRES:
                 raise NotImplementedError('This function was not expected to be called')
 
 
-@unittest.skipUnless(HAS_POSTGRES, "The psycopg2 driver is needed for these tests")
+@unittest.skipUnless(HAS_POSTGRES, "The psycopg driver is needed for these tests")
 class TestPostGISVersionCheck(unittest.TestCase):
     """
     The PostGIS version check parses correctly the version numbers

--- a/tests/postgres_tests/test_apps.py
+++ b/tests/postgres_tests/test_apps.py
@@ -1,22 +1,31 @@
+import unittest
+from decimal import Decimal
+
+from django.db import connection
 from django.db.backends.signals import connection_created
 from django.db.migrations.writer import MigrationWriter
+from django.test import TestCase
 from django.test.utils import modify_settings
 
-from . import PostgreSQLTestCase
-
 try:
-    from psycopg2.extras import (
-        DateRange, DateTimeRange, DateTimeTZRange, NumericRange,
-    )
-
     from django.contrib.postgres.fields import (
-        DateRangeField, DateTimeRangeField, IntegerRangeField,
+        DateRangeField,
+        DateTimeRangeField,
+        IntegerRangeField,
+    )
+    from django.db.backends.postgresql.psycopg_any import (
+        DateRange,
+        DateTimeRange,
+        DateTimeTZRange,
+        NumericRange,
+        is_psycopg3,
     )
 except ImportError:
     pass
 
 
-class PostgresConfigTests(PostgreSQLTestCase):
+@unittest.skipUnless(connection.vendor == "postgresql", "PostgreSQL specific tests")
+class PostgresConfigTests(TestCase):
     def test_register_type_handlers_connection(self):
         from django.contrib.postgres.signals import register_type_handlers
         self.assertNotIn(register_type_handlers, connection_created._live_receivers(None))
@@ -40,21 +49,22 @@ class PostgresConfigTests(PostgreSQLTestCase):
                         MigrationWriter.serialize(field)
 
         assertNotSerializable()
+        import_name = "psycopg.types.range" if is_psycopg3 else "psycopg2.extras"
         with self.modify_settings(INSTALLED_APPS={'append': 'django.contrib.postgres'}):
             for default, test_field in tests:
                 with self.subTest(default=default):
                     field = test_field(default=default)
                     serialized_field, imports = MigrationWriter.serialize(field)
-                    self.assertEqual(imports, {
-                        'import django.contrib.postgres.fields.ranges',
-                        'import psycopg2.extras',
-                    })
+                    self.assertEqual(
+                        imports,
+                        {
+                            "import django.contrib.postgres.fields.ranges",
+                            f"import {import_name}",
+                        },
+                    )
                     self.assertIn(
-                        '%s.%s(default=psycopg2.extras.%r)' % (
-                            field.__module__,
-                            field.__class__.__name__,
-                            default,
-                        ),
-                        serialized_field
+                        f"{field.__module__}.{field.__class__.__name__}"
+                        f"(default={import_name}.{default!r})",
+                        serialized_field,
                     )
         assertNotSerializable()

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -283,7 +283,7 @@ class TestQuerying(PostgreSQLTestCase):
     def test_in_including_F_object(self):
         # This test asserts that Array objects passed to filters can be
         # constructed to contain F objects. This currently doesn't work as the
-        # psycopg2 mogrify method that generates the ARRAY() syntax is
+        # psycopg mogrify method that generates the ARRAY() syntax is
         # expecting literals, not column references (#27095).
         self.assertSequenceEqual(
             NullableIntegerArrayModel.objects.filter(field__in=[[models.F('id')]]),

--- a/tests/requirements/postgres.txt
+++ b/tests/requirements/postgres.txt
@@ -1,1 +1,1 @@
-psycopg2>=2.5.4
+psycopg[binary]>=3.1

--- a/tests/schema/test_logging.py
+++ b/tests/schema/test_logging.py
@@ -10,9 +10,9 @@ class SchemaLoggerTests(TestCase):
         params = [42, 1337]
         with self.assertLogs('django.db.backends.schema', 'DEBUG') as cm:
             editor.execute(sql, params)
+        if connection.features.schema_editor_uses_clientside_param_binding:
+            sql = "SELECT * FROM foo WHERE id in (42, 1337)"
+            params = None
         self.assertEqual(cm.records[0].sql, sql)
         self.assertEqual(cm.records[0].params, params)
-        self.assertEqual(
-            cm.records[0].getMessage(),
-            'SELECT * FROM foo WHERE id in (%s, %s); (params [42, 1337])',
-        )
+        self.assertEqual(cm.records[0].getMessage(), f"{sql}; (params {params})")


### PR DESCRIPTION
Thanks Simon Charette, Tim Graham, and Adam Johnson for reviews.

Co-authored-by: Florian Apolloner <florian@apolloner.eu>
Co-authored-by: Mariusz Felisiak <felisiak.mariusz@gmail.com>

# Conflicts:
#	django/contrib/gis/db/backends/postgis/adapter.py #	django/contrib/gis/db/backends/postgis/operations.py #	django/contrib/postgres/fields/array.py
#	django/contrib/postgres/fields/ranges.py
#	django/contrib/postgres/search.py
#	django/contrib/postgres/signals.py
#	django/core/management/commands/loaddata.py
#	django/db/backends/base/features.py
#	django/db/backends/postgresql/base.py
#	django/db/backends/postgresql/features.py
#	django/db/backends/postgresql/operations.py
#	django/db/backends/postgresql/psycopg_any.py
#	django/db/backends/postgresql/schema.py
#	docs/conf.py
#	docs/ref/contrib/gis/install/postgis.txt
#	docs/ref/contrib/postgres/fields.txt
#	docs/ref/databases.txt
#	docs/releases/4.2.txt
#	tests/backends/postgresql/tests.py
#	tests/backends/tests.py
#	tests/db_functions/datetime/test_extract_trunc.py #	tests/fixtures/tests.py
#	tests/model_fields/test_jsonfield.py
#	tests/postgres_tests/test_apps.py
#	tests/requirements/postgres.txt
#	tests/schema/test_logging.py